### PR TITLE
Adding tests using the Guzzle/PSR7 implementation 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "require": {
         "php": "~5.5|~7.0",
         "league/route": "^2.0",
-        "zendframework/zend-diactoros": "^1.3"
+        "zendframework/zend-diactoros": "^1.3",
+        "guzzlehttp/psr7": "^1.3"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0||~5.0",

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,14 @@
     "require": {
         "php": "~5.5|~7.0",
         "league/route": "^2.0",
-        "zendframework/zend-diactoros": "^1.3",
-        "guzzlehttp/psr7": "^1.3"
+        "zendframework/zend-diactoros": "^1.3"
+
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0||~5.0",
         "scrutinizer/ocular": "~1.1",
-        "squizlabs/php_codesniffer": "~2.3"
+        "squizlabs/php_codesniffer": "~2.3",
+        "guzzlehttp/psr7": "^1.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
replacing the Zend/Diactoros implementation in the container to demonstrate that any (the only two I found that look usable) PSR7 implementation can be used.