### PR TITLE
Add support for middleware.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,15 @@
     "require": {
         "php": "~5.5|~7.0",
         "league/route": "^2.0",
-        "zendframework/zend-diactoros": "^1.3"
+        "zendframework/zend-diactoros": "^1.3",
+        "equip/dispatch": "^0.2",
+        "middlewares/response-time": "0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0||~5.0",
         "scrutinizer/ocular": "~1.1",
-        "squizlabs/php_codesniffer": "~2.3"
+        "squizlabs/php_codesniffer": "~2.3",
+        "guzzlehttp/psr7": "^1.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/Application.php
+++ b/src/Application.php
@@ -2,6 +2,7 @@
 
 namespace CodeJet\Roots;
 
+use Equip\Dispatch\MiddlewarePipe;
 use League\Container\ContainerInterface;
 
 class Application
@@ -17,7 +18,7 @@ class Application
     {
         $this->container = $container;
 
-        // Now... to bootstrap the app with configuration..
+        // Bootstrap the app with configuration..
         // Middleware, Routes, Services, etc...
     }
 
@@ -40,12 +41,23 @@ class Application
      */
     public function getResponse()
     {
-        $response = $this->getRouter()->dispatch(
-            $this->getPsrRequest(),
+        $routerMiddleware = new RouterMiddlewarinator(
+            $this->getRouter(),
             $this->getPsrResponse()
         );
 
-        return $response;
+        $middleware = $this->getMiddlewareStack();
+
+        array_push($middleware, $routerMiddleware);
+
+        $pipe = new MiddlewarePipe($middleware);
+
+        return $pipe->dispatch(
+            $this->getPsrRequest(),
+            function () {
+                throw new \Exception('Our tree has no leaves.. and subsequently died from lack of middleware.');
+            }
+        );
     }
 
     /**

--- a/src/DefaultServiceGetter.php
+++ b/src/DefaultServiceGetter.php
@@ -8,8 +8,19 @@ namespace CodeJet\Roots;
 
 trait DefaultServiceGetter
 {
+    public function getMiddlewareStack()
+    {
+        if (!$this->container->has('middlewareStack')) {
+            $this->container->share('middlewareStack', [
+                new \Middlewares\ResponseTime()
+            ]);
+        }
+
+        return $this->container->get('middlewareStack');
+    }
+
     /**
-     * @return \League\Route\RouteCollectionInterface
+     * @return \League\Route\RouteCollection
      */
     public function getRouter()
     {

--- a/src/RouterMiddlewarinator.php
+++ b/src/RouterMiddlewarinator.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Make PSR7 Router's PSR15 Middleware friendly.
+ */
+namespace CodeJet\Roots;
+
+use Interop\Http\Middleware\DelegateInterface;
+use Interop\Http\Middleware\ServerMiddlewareInterface;
+use League\Route\RouteCollection;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class RouterMiddlewarinator implements ServerMiddlewareInterface
+{
+    /**
+     * @var RouteCollection
+     */
+    protected $router;
+    /**
+     * @var ResponseInterface
+     */
+    protected $response;
+
+    /**
+     * RouterMiddlewarinator constructor.
+     *
+     * @param RouteCollection $router
+     * @param ResponseInterface $response
+     */
+    public function __construct(RouteCollection $router, ResponseInterface $response)
+    {
+        $this->router = $router;
+        $this->response = $response;
+    }
+
+    /**
+     * @param ServerRequestInterface $request
+     * @param DelegateInterface $delegate
+     *
+     * @return ResponseInterface
+     */
+    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    {
+        return $this->router->dispatch(
+            $request,
+            $this->response
+        );
+    }
+}


### PR DESCRIPTION
Added a default middleware stack that consists of the response time generator.
 In order to support PSR15, but not gut the PSR7-only router a RouterMiddlewarinator exists to abstract the MiddleWareInterface and allow the router to be added to the end of the middleware stack.